### PR TITLE
Localhost redirect uri fix and prompt user to export region in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Set environment variables:
 ```bash
 export TECH_AUDIT_DATA_BUCKET='sdp-dev-tech-audit-tool-api'
 export TECH_AUDIT_SECRET_MANAGER='sdp-dev-tech-audit-tool-api/secrets'
+export REDIRECT_URI='http://localhost:8000'
 export AWS_COGNITO_TOKEN_URL='https://tech-audit-tool-api-sdp-dev.auth.eu-west-2.amazoncognito.com/oauth2/token'
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Set environment variables:
 ```bash
 export TECH_AUDIT_DATA_BUCKET='sdp-dev-tech-audit-tool-api'
 export TECH_AUDIT_SECRET_MANAGER='sdp-dev-tech-audit-tool-api/secrets'
-export REDIRECT_URI='http://localhost:8000'
 export AWS_COGNITO_TOKEN_URL='https://tech-audit-tool-api-sdp-dev.auth.eu-west-2.amazoncognito.com/oauth2/token'
+export AWS_DEFAULT_REGION='eu-west-2'
+export REDIRECT_URI='http://localhost:8000'
 ```
 
 Go to the aws_lambda_script directory

--- a/aws_lambda_script/app/resources.py
+++ b/aws_lambda_script/app/resources.py
@@ -512,7 +512,7 @@ class ProjectDetail(Resource):
 cognito_settings = cognito_data
 COGNITO_CLIENT_ID = cognito_settings["COGNITO_CLIENT_ID"]
 COGNITO_CLIENT_SECRET = cognito_settings["COGNITO_CLIENT_SECRET"]
-REDIRECT_URI = cognito_settings["REDIRECT_URI"]
+REDIRECT_URI = os.getenv("REDIRECT_URI", cognito_settings["REDIRECT_URI"])
 
 verifyParser = reqparse.RequestParser()
 verifyParser.add_argument(


### PR DESCRIPTION
Running locally, the program would use the secrets value in Secrets Manager to import the redirect URI. A getenv is set to get the local variable or default to the secrets value.

Also forgot to add `export AWS_DEFAULT_REGION=eu-west-2` in the README.