### PR TITLE
KEH-1797 Modularising lambda

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -38,6 +38,10 @@ Run like normal.
 
 The tech audit S3 bucket and the secrets manager secret are created by the terraform script. The aws cognito token url is set by the terraform script. Then run the terraform script for the lambda function and this data is set in the lambda function.
 
+The Lambda Terraform now composes shared modules for the IAM role/security group and the Lambda resource itself. You still provide the image details via `ecr_repository` and `container_ver` (tag). Optionally, you can pin to an immutable image digest using `container_digest` to avoid tag lookup issues.
+
+After apply, you can confirm the exact image (including digest) via the `lambda_image_uri` Terraform output.
+
 ### 6. API Gateway
 
 Run like normal. Note down the URLs in the outputs.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -64,6 +64,10 @@ Run like normal.
 ### 5. Lambda Function
 The tech audit S3 bucket and the secrets manager secret are created by the terraform script. The aws cognito token url is set by the terraform script. Then run the terraform script for the lambda function and this data is set in the lambda function.
 
+The Lambda Terraform composes shared modules for the IAM role/security group and the Lambda resource. Configure the container image with `ecr_repository` and `container_ver` (tag). If needed, you can pin the image using `container_digest` (sha256:...) to avoid tag-based lookup failures.
+
+After apply, use the `lambda_image_uri` output to confirm the exact image URI (including digest).
+
 ### 6. API Gateway
 Run like normal. Note down the URLs in the outputs.
 

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -8,178 +8,61 @@ terraform {
   }
 
 }
+#1. IAM Role and Security Group for Lambda
+module "lambda_role_and_sg" {
+  source = "git::https://github.com/ONSdigital/ons-terraform-modular.git//terraform/lambda/lambda_role_and_sg?ref=KEH-1797-shared-terraform-repo"
 
-# 1. First create the IAM role
-resource "aws_iam_role" "lambda_execution_role" {
-  name = "${var.domain}-${var.service_subdomain}-lambda-role"
+  domain            = var.domain
+  service_subdomain = var.service_subdomain
+  region            = var.region
+  aws_account_id    = var.aws_account_id
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
-      }
-    ]
-  })
-}
+  vpc_id        = data.terraform_remote_state.vpc.outputs.vpc_id
+  s3_bucket_name = data.terraform_remote_state.storage.outputs.tech_audit_data_bucket_name
+  secret_arn     = data.terraform_remote_state.secrets.outputs.secret_arn
 
-# 2. Attach basic execution policy
-resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
-  role       = aws_iam_role.lambda_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  depends_on = [aws_iam_role.lambda_execution_role]
-}
+  ingress_https_cidr_blocks = ["10.0.0.0/16"]
 
-# 3. Add S3 access policy
-resource "aws_iam_role_policy" "lambda_s3_access" {
-  name = "${var.domain}-${var.service_subdomain}-lambda-s3-policy"
-  role = aws_iam_role.lambda_execution_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:PutObject",
-          "s3:GetObject",
-          "s3:ListBucket"
-        ]
-        Resource = [
-          "arn:aws:s3:::${data.terraform_remote_state.storage.outputs.tech_audit_data_bucket_name}",
-          "arn:aws:s3:::${data.terraform_remote_state.storage.outputs.tech_audit_data_bucket_name}/*"
-        ]
-      }
-    ]
-  })
-  depends_on = [aws_iam_role.lambda_execution_role]
-}
-
-# 4. Add additional permissions
-resource "aws_iam_role_policy" "lambda_additional_permissions" {
-  name = "${var.domain}-${var.service_subdomain}-policy-additional"
-  role = aws_iam_role.lambda_execution_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = data.terraform_remote_state.secrets.outputs.secret_arn
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "logs:CreateLogGroup"
-        ]
-        Resource = "arn:aws:logs:${var.region}:${var.aws_account_id}:*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
-        ]
-        Resource = [
-          "arn:aws:logs:${var.region}:${var.aws_account_id}:log-group:/aws/lambda/${var.domain}-${var.service_subdomain}-lambda:*"
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "logs:CreateLogGroup",
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
-        ]
-        Resource = "*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "execute-api:Invoke",
-          "execute-api:ManageConnections"
-        ]
-        Resource = "arn:aws:execute-api:*:*:*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:*",
-          "s3-object-lambda:*"
-        ]
-        Resource = "arn:aws:s3:::${var.domain}-${var.service_subdomain}/*"
-      }
-    ]
-  })
-  depends_on = [aws_iam_role.lambda_execution_role]
-}
-
-# 5. Create the security group
-resource "aws_security_group" "lambda_sg" {
-  name = "${var.domain}-${var.service_subdomain}-lambda-sg"
-  description = "Security group for ${var.domain}-${var.service_subdomain}-lambda Lambda function"
-  vpc_id = data.terraform_remote_state.vpc.outputs.vpc_id
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"] // Allow HTTPS traffic within VPC
-  }  
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # Optional: extra broad S3 stanza
+  extra_s3_resource_arn = "arn:aws:s3:::${var.domain}-${var.service_subdomain}/*"
 
   tags = {
-    Name = "${var.domain}-${var.service_subdomain}-lambda-sg"
+    Service = var.service_subdomain
+    Domain  = var.domain
   }
 }
 
-# 6. Create the Lambda function
+# 2. Create the Lambda function
 module "tech_audit_lambda" {
-  source = "git::https://github.com/ONSdigital/ons-terraform-modular.git//terraform/lambda/modules/aws_lambda?ref=v1.0.0"
+  source = "git::https://github.com/ONSdigital/ons-terraform-modular.git//terraform/lambda?ref=KEH-1797-shared-terraform-repo"
 
   function_name = "${var.domain}-${var.service_subdomain}-lambda"
   image_uri = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.ecr_repository}@${data.aws_ecr_image.lambda_image.image_digest}"
 
-  role_arn  = aws_iam_role.lambda_execution_role.arn
+  role_arn  = module.lambda_role_and_sg.role_arn
 
   subnet_ids          = data.terraform_remote_state.vpc.outputs.private_subnets
-  security_group_ids  = [aws_security_group.lambda_sg.id] // Dedicated security group for Lambda function
+  security_group_ids  = [module.lambda_role_and_sg.security_group_id] // Dedicated security group for Lambda function
 
-  environment_variables {
-    variables = {
-      TECH_AUDIT_DATA_BUCKET     = data.terraform_remote_state.storage.outputs.tech_audit_data_bucket_name
-      TECH_AUDIT_SECRET_MANAGER  = data.terraform_remote_state.secrets.outputs.secret_name
-      AWS_COGNITO_TOKEN_URL      = "https://${var.domain}-${var.service_subdomain}.auth.eu-west-2.amazoncognito.com/oauth2/token"
-      IMAGE_DIGEST               = data.aws_ecr_image.lambda_image.image_digest
-      IMAGE_TAG                  = var.container_ver
-    }
+  environment_variables = {
+    TECH_AUDIT_DATA_BUCKET     = data.terraform_remote_state.storage.outputs.tech_audit_data_bucket_name
+    TECH_AUDIT_SECRET_MANAGER  = data.terraform_remote_state.secrets.outputs.secret_name
+    AWS_COGNITO_TOKEN_URL      = "https://${var.domain}-${var.service_subdomain}.auth.${var.region}.amazoncognito.com/oauth2/token"
+    IMAGE_DIGEST               = data.aws_ecr_image.lambda_image.image_digest
+    IMAGE_TAG                  = var.container_ver
   }
 
   depends_on = [
-    aws_iam_role_policy.lambda_s3_access,
-    aws_iam_role_policy.lambda_additional_permissions,
-    aws_iam_role_policy_attachment.lambda_basic_execution,
-    aws_iam_role_policy_attachment.lambda_vpc_access,
+    module.lambda_role_and_sg,
     data.aws_ecr_image.lambda_image
   ]
 }
 
 # Add VPC access policy to Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
-  role       = aws_iam_role.lambda_execution_role.name
+  role       = basename(module.lambda_role_and_sg.role_arn)
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
-  depends_on = [aws_iam_role.lambda_execution_role]
+  depends_on = [module.lambda_role_and_sg]
 }
 
 # Resolve the pushed image (must exist before terraform apply)

--- a/terraform/lambda/outputs.tf
+++ b/terraform/lambda/outputs.tf
@@ -1,11 +1,11 @@
 output "lambda_function_arn" {
-  value = aws_lambda_function.tech_audit_lambda.arn
+  value = module.tech_audit_lambda.lambda_function_arn
 }
 
 output "lambda_function_name" {
-  value = aws_lambda_function.tech_audit_lambda.function_name
+  value = module.tech_audit_lambda.lambda_function_name
 }
 
 output "lambda_execution_role_arn" {
-  value = aws_iam_role.lambda_execution_role.arn
+  value = module.lambda_role_and_sg.role_arn
 } 

--- a/terraform/lambda/outputs.tf
+++ b/terraform/lambda/outputs.tf
@@ -9,3 +9,8 @@ output "lambda_function_name" {
 output "lambda_execution_role_arn" {
   value = module.lambda_role_and_sg.role_arn
 } 
+
+output "lambda_image_uri" {
+  description = "ECR image URI (including digest) used by the Lambda function"
+  value       = local.lambda_image_uri
+}

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -43,6 +43,12 @@ variable "container_ver" {
 
 }
 
+variable "container_digest" {
+  description = "Optional. ECR image digest (sha256:...) to use instead of looking up by tag. Useful when tag-based lookup fails or for fully pinned deploys."
+  type        = string
+  default     = null
+}
+
 variable "project_tag" {
   description = "Project"
   type        = string


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

### What

Modified the `terraform/lambda/main.tf, outputs.tf and variables.tf` files.
Moved resources to a shared repository `https://github.com/ONSdigital/ons-terraform-modular`.

The "IAM role", "policies" and "security group" are now created by `module.lambda_role_and_sg` instead of inline.
The "Lambda function" is now created by `module.tech_audit_lambda.lambda_function_arn / lambda_function_name` instead of inline.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
The modification to the terraform does not have any dependent tests, therefore not require new tests or modification to existing tests.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [x] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1797

### How to review

check if the terraform changes are up to the tickets acceptance